### PR TITLE
Use poetry for dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Ignore files output by script
+*.docx

--- a/README.md
+++ b/README.md
@@ -1,18 +1,28 @@
 # docx-csv-mailmerge
+
 Generates .docx files from .csv files using a .docx template with mailmerge fields.
 
-## Required
-- [docx-mailmerge](https://pypi.org/project/docx-mailmerge/)
-- Microsoft Office Word
+## Installing
 
-**NOTE** docx-mailmerge is based on [lxml](https://lxml.de/installation.html), which for MacOS users _like myself_ is currently only available through a [MacPorts](https://www.macports.org/install.php). This then only allows the use of Python 2.7 - not 3. That is why this code is executed with Python 2.7. I have yet to test it on a Windows Machine.
+We use [poetry](https://python-poetry.org/) for dependency management and
+[pyenv](https://github.com/pyenv/pyenv) to manage python installations. Once
+they are installed, you can install the dependencies for this project as:
+
+    poetry install
+
+To setup a virtual environment with your local pyenv version run:
+
+    poetry shell
 
 ## Usage
-If you have the required package(s) installed (see above), put the docx-csv-mailmerge.py into the same folder as your .docx template and .csv data file. Then, run:
+
+Move your `.docx` template and `.csv data file` into the folder of this repo and run:
 
     python docx-csv-mailmerge.py data.csv template.docx ";"
 
-where the first argument is the .csv file, the second the template, and the third the delimiter as used in the .csv between "quotation marks". You can also use absolute paths to the files, just make sure you add "" around these for escaping characters, for example:
+Where the arguments are your data to apply to the word template (in .`csv` format), your word template and the delimiter used in the `csv` file.
+
+You can also use absolute paths to the files, just make sure you add "" around these for escaping characters, for example:
 
     python docx-csv-mailmerge.py "path/to/data.csv" "path/to/template.docx" "/"
 
@@ -30,12 +40,3 @@ You should see something like this `{ MERGEFIELD \* MERGEFORMAT}`. Add a name fo
 To try out this template, use - or add some lines to - the example_data.csv. Then, run
 
      python docx-csv-mailmerge.py example_data.csv example_template.docx ";"
-
-## Bonus
-Use [docx2pdf](https://github.com/AlJohri/docx2pdf) to batch convert the generated .docx documents into .pdfs. In my experience, I had to run docx2pdf once, grant access to Microsoft Word, and could then run the whole batch nicely. I first moved all generated .docx to a folder to use the folder-batch from docx2pdf easily.
-
-I might turn this together into a bash script in the future.
-
-
-# TODO
-- Test on a Windows Machine

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ Generates .docx files from .csv files using a .docx template with mailmerge fiel
 
 ## Installing
 
-We use [poetry](https://python-poetry.org/) for dependency management and
-[pyenv](https://github.com/pyenv/pyenv) to manage python installations. Once
-they are installed, you can install the dependencies for this project as:
+[Poetry](https://python-poetry.org/) is used for dependency management and
+[pyenv](https://github.com/pyenv/pyenv) to manage python installations. Install dependencies via:
 
     poetry install
 

--- a/docx-csv-mailmerge.py
+++ b/docx-csv-mailmerge.py
@@ -1,11 +1,3 @@
-#!/usr/bin/env python
-
-__author__ = "David Verweij"
-__license__ = "MIT"
-__version__ = "0.1"
-__email__ = "davidverweij@gmail.com"
-__status__ = "Work in Progress"
-
 from mailmerge import MailMerge
 import sys
 import csv

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,63 @@
+[[package]]
+category = "main"
+description = "Performs a Mail Merge on docx (Microsoft Office Word) files"
+name = "docx-mailmerge"
+optional = false
+python-versions = "*"
+version = "0.5.0"
+
+[package.dependencies]
+lxml = "*"
+
+[[package]]
+category = "main"
+description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
+name = "lxml"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
+version = "4.5.0"
+
+[package.extras]
+cssselect = ["cssselect (>=0.7)"]
+html5 = ["html5lib"]
+htmlsoup = ["beautifulsoup4"]
+source = ["Cython (>=0.29.7)"]
+
+[metadata]
+content-hash = "85c1da8d3c187ae3ff55d0385316c088bb3535b0b610a5b9062c3cc4852d37b0"
+python-versions = "^2.7.0"
+
+[metadata.files]
+docx-mailmerge = [
+    {file = "docx-mailmerge-0.5.0.tar.gz", hash = "sha256:6fbe353bd2f87dc6621d9add7bd04896181a469cc543502f1acc0c2444fd632a"},
+    {file = "docx_mailmerge-0.5.0-py2.py3-none-any.whl", hash = "sha256:0c9d8a0e9230ec337d7e43014280fe6c0b7773adadbfe5f1d9f764d37f072137"},
+]
+lxml = [
+    {file = "lxml-4.5.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:0701f7965903a1c3f6f09328c1278ac0eee8f56f244e66af79cb224b7ef3801c"},
+    {file = "lxml-4.5.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:06d4e0bbb1d62e38ae6118406d7cdb4693a3fa34ee3762238bcb96c9e36a93cd"},
+    {file = "lxml-4.5.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5828c7f3e615f3975d48f40d4fe66e8a7b25f16b5e5705ffe1d22e43fb1f6261"},
+    {file = "lxml-4.5.0-cp27-cp27m-win32.whl", hash = "sha256:afdb34b715daf814d1abea0317b6d672476b498472f1e5aacbadc34ebbc26e89"},
+    {file = "lxml-4.5.0-cp27-cp27m-win_amd64.whl", hash = "sha256:585c0869f75577ac7a8ff38d08f7aac9033da2c41c11352ebf86a04652758b7a"},
+    {file = "lxml-4.5.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:8a0ebda56ebca1a83eb2d1ac266649b80af8dd4b4a3502b2c1e09ac2f88fe128"},
+    {file = "lxml-4.5.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:fe976a0f1ef09b3638778024ab9fb8cde3118f203364212c198f71341c0715ca"},
+    {file = "lxml-4.5.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:7bc1b221e7867f2e7ff1933165c0cec7153dce93d0cdba6554b42a8beb687bdb"},
+    {file = "lxml-4.5.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:d068f55bda3c2c3fcaec24bd083d9e2eede32c583faf084d6e4b9daaea77dde8"},
+    {file = "lxml-4.5.0-cp35-cp35m-win32.whl", hash = "sha256:e4aa948eb15018a657702fee0b9db47e908491c64d36b4a90f59a64741516e77"},
+    {file = "lxml-4.5.0-cp35-cp35m-win_amd64.whl", hash = "sha256:1f2c4ec372bf1c4a2c7e4bb20845e8bcf8050365189d86806bad1e3ae473d081"},
+    {file = "lxml-4.5.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:5d467ce9c5d35b3bcc7172c06320dddb275fea6ac2037f72f0a4d7472035cea9"},
+    {file = "lxml-4.5.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:95e67224815ef86924fbc2b71a9dbd1f7262384bca4bc4793645794ac4200717"},
+    {file = "lxml-4.5.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ebec08091a22c2be870890913bdadd86fcd8e9f0f22bcb398abd3af914690c15"},
+    {file = "lxml-4.5.0-cp36-cp36m-win32.whl", hash = "sha256:deadf4df349d1dcd7b2853a2c8796593cc346600726eff680ed8ed11812382a7"},
+    {file = "lxml-4.5.0-cp36-cp36m-win_amd64.whl", hash = "sha256:f2b74784ed7e0bc2d02bd53e48ad6ba523c9b36c194260b7a5045071abbb1012"},
+    {file = "lxml-4.5.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fa071559f14bd1e92077b1b5f6c22cf09756c6de7139370249eb372854ce51e6"},
+    {file = "lxml-4.5.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:edc15fcfd77395e24543be48871c251f38132bb834d9fdfdad756adb6ea37679"},
+    {file = "lxml-4.5.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:fd52e796fee7171c4361d441796b64df1acfceb51f29e545e812f16d023c4bbc"},
+    {file = "lxml-4.5.0-cp37-cp37m-win32.whl", hash = "sha256:90ed0e36455a81b25b7034038e40880189169c308a3df360861ad74da7b68c1a"},
+    {file = "lxml-4.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:df533af6f88080419c5a604d0d63b2c33b1c0c4409aba7d0cb6de305147ea8c8"},
+    {file = "lxml-4.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b4b2c63cc7963aedd08a5f5a454c9f67251b1ac9e22fd9d72836206c42dc2a72"},
+    {file = "lxml-4.5.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e5d842c73e4ef6ed8c1bd77806bf84a7cb535f9c0cf9b2c74d02ebda310070e1"},
+    {file = "lxml-4.5.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:63dbc21efd7e822c11d5ddbedbbb08cd11a41e0032e382a0fd59b0b08e405a3a"},
+    {file = "lxml-4.5.0-cp38-cp38-win32.whl", hash = "sha256:4235bc124fdcf611d02047d7034164897ade13046bda967768836629bc62784f"},
+    {file = "lxml-4.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:d5b3c4b7edd2e770375a01139be11307f04341ec709cf724e0f26ebb1eef12c3"},
+    {file = "lxml-4.5.0.tar.gz", hash = "sha256:8620ce80f50d023d414183bf90cc2576c2837b88e00bea3f33ad2630133bbb60"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "docx-csv-mailmerge"
+version = "0.0.1"
+description = "Generates .docx files from .csv files using a .docx template with mailmerge fields."
+authors = ["David Verweij <davidverweij@gmail.com>"]
+license = "MIT"
+readme = "README.md"
+homepage = "https://github.com/davidverweij/docx-csv-mailmerge"
+repository = "https://github.com/davidverweij/docx-csv-mailmerge"
+
+[tool.poetry.dependencies]
+python = "^2.7.0"
+docx-mailmerge = "^0.5.0"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"


### PR DESCRIPTION
I've added a poetry configuration to the project to separate installation of libraries to a virtual environment. Poetry will also make future publishing of the library easier, and once the `docx-csv-mailmerge.py` has been improved to a CLI it will make running the library (via poetry) much easier.

I created the poetry `.toml` file to mirror the choice and use of python 2.7 as upgrading to python 3 requires making several changes to `docx-csv-mailmerge.py`, which should be done in a separate PR 👍

Verify these changes by fetching and pulling down the repo and following my instructions in the `README`. 